### PR TITLE
【FIXBUG】修复缩放 bitmap 时空指针的问题；修复创建 Notification 时，SongInfo 空指针的问题；

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /build
 /captures
 .externalNativeBuild
+.idea

--- a/musiclibrary/src/main/java/com/lzx/musiclibrary/helper/BitmapHelper.java
+++ b/musiclibrary/src/main/java/com/lzx/musiclibrary/helper/BitmapHelper.java
@@ -30,6 +30,9 @@ public class BitmapHelper {
     private static final int MAX_READ_LIMIT_PER_IMG = 1024 * 1024;
 
     public static Bitmap scaleBitmap(Bitmap src, int maxWidth, int maxHeight) {
+        if (src == null || src.getHeight() == 0 || src.getWidth() == 0) {
+            return null;
+        }
        double scaleFactor = Math.min(
            ((double) maxWidth)/src.getWidth(), ((double) maxHeight)/src.getHeight());
         return Bitmap.createScaledBitmap(src,

--- a/musiclibrary/src/main/java/com/lzx/musiclibrary/notification/SystemNotification.java
+++ b/musiclibrary/src/main/java/com/lzx/musiclibrary/notification/SystemNotification.java
@@ -169,7 +169,7 @@ public class SystemNotification implements IMediaNotification {
     }
 
     private Notification createNotification() {
-        if (mNotificationCreater != null && !TextUtils.isEmpty(mNotificationCreater.getTargetClass())) {
+        if (mSongInfo != null && mNotificationCreater != null && !TextUtils.isEmpty(mNotificationCreater.getTargetClass())) {
             Class clazz = getTargetClass(mNotificationCreater.getTargetClass());
 
             String fetchArtUrl = null;


### PR DESCRIPTION
解决 crash-1
java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String com.lzx.musiclibrary.aidl.model.SongInfo.getSongCover()' on a null object reference
at com.lzx.musiclibrary.notification.SystemNotification.createNotification(SystemNotification.java:177)

解决 crash-2
Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'int android.graphics.Bitmap.getWidth()' on a null object reference
at com.lzx.musiclibrary.helper.BitmapHelper.scaleBitmap(BitmapHelper.java:34)