### PR TITLE
修复随机播放仅在列表个别曲目中循环

### DIFF
--- a/starrysky/src/main/java/com/lzx/starrysky/queue/MediaQueueManager.kt
+++ b/starrysky/src/main/java/com/lzx/starrysky/queue/MediaQueueManager.kt
@@ -75,7 +75,11 @@ class MediaQueueManager(val provider: MediaSourceProvider) {
     }
 
     fun updateIndexBySongId(songId: String): Boolean {
-        val index = provider.getIndexById(songId)
+        val index = if (RepeatMode.with.repeatMode.isModeShuffle()) {
+            provider.getIndexById(songId,true)
+        } else {
+            provider.getIndexById(songId)
+        }
         val list = provider.songList
         if (index.isIndexPlayable(list)) {
             currentIndex = index

--- a/starrysky/src/main/java/com/lzx/starrysky/queue/MediaSourceProvider.kt
+++ b/starrysky/src/main/java/com/lzx/starrysky/queue/MediaSourceProvider.kt
@@ -104,9 +104,14 @@ class MediaSourceProvider {
         return songList.elementAtOrNull(index)
     }
 
-    fun getIndexById(songId: String): Int {
+    fun getIndexById(songId: String, isShuffle:Boolean = false): Int {
         val info = getSongInfoById(songId)
-        return if (info != null) songList.indexOf(info) else -1
+        return if (info != null) {
+            when (isShuffle) {
+                true -> shuffleSongSources.indexOf(info)
+                false -> songList.indexOf(info)
+            }
+        } else -1
     }
 
     fun updateMusicArt(songInfo: SongInfo) {


### PR DESCRIPTION
具体原因：

PlaybackManager 的 onSkipToNext() 方法调用 mediaQueue.skipQueuePosition()，修改了 MediaQueueManager 的 _currentIndex_。接着 PlaybackManager 又会调用 onPlayMusicImpl() 方法，这个方法内会调用 mediaQueue.updateIndexBySongId()，再次修改 _currentIndex_。

问题就在于 MediaQueueManager 的 updateIndexBySongId() 没有考虑是否为随机播放，一律从 MediaSourceProvider 的 songList 去找，就会出现问题。

在两个方法添加了判断。